### PR TITLE
Support updating edition sets in ArtworkAttributeUpdatable

### DIFF
--- a/src/artwork_availability_quick_edit.js
+++ b/src/artwork_availability_quick_edit.js
@@ -30,10 +30,12 @@ const ArtworkAvailabilityQuickEdit = ArtworkAttributeUpdatable(InlineArtworkAvai
 ArtworkAvailabilityQuickEdit.propTypes = {
   artwork: React.PropTypes.object.isRequired,
   saveUrl: React.PropTypes.string.isRequired,
+  isEditionSet: React.PropTypes.bool,
   options: React.PropTypes.array.isRequired
 }
 
 ArtworkAvailabilityQuickEdit.defaultProps = {
+  isEditionSet: false
 }
 
 export default ArtworkAvailabilityQuickEdit;

--- a/src/artwork_price_quick_edit.js
+++ b/src/artwork_price_quick_edit.js
@@ -29,10 +29,12 @@ const ArtworkPriceQuickEdit = ArtworkAttributeUpdatable(InlineArtworkPrice);
 ArtworkPriceQuickEdit.propTypes = {
   artwork: React.PropTypes.object.isRequired,
   saveUrl: React.PropTypes.string.isRequired,
+  isEditionSet: React.PropTypes.bool,
   t: React.PropTypes.object
 }
 
 ArtworkPriceQuickEdit.defaultProps = {
+  isEditionSet: false
 }
 
 export default ArtworkPriceQuickEdit;

--- a/src/artwork_price_visibility_quick_edit.js
+++ b/src/artwork_price_visibility_quick_edit.js
@@ -36,10 +36,12 @@ const ArtworkPriceVisibilityQuickEdit = ArtworkAttributeUpdatable(InlineArtworkP
 ArtworkPriceVisibilityQuickEdit.propTypes = {
   artwork: React.PropTypes.object.isRequired,
   saveUrl: React.PropTypes.string.isRequired,
+  isEditionSet: React.PropTypes.bool,
   options: React.PropTypes.array.isRequired
 }
 
 ArtworkPriceVisibilityQuickEdit.defaultProps = {
+  isEditionSet: false
 }
 
 export default ArtworkPriceVisibilityQuickEdit;

--- a/src/base/inline_dropdown.js
+++ b/src/base/inline_dropdown.js
@@ -48,7 +48,6 @@ class InlineDropdown extends React.Component {
           onSubmit={this.props.onSubmit}
         >
           <FormGroup>
-            <input name="ignore_blank" value="true" type="hidden" />
             <FormControl
               componentClass="select"
               name={this.props.attribute}

--- a/src/base/inline_text_input.js
+++ b/src/base/inline_text_input.js
@@ -26,7 +26,6 @@ class InlineTextInput extends React.Component {
           onSubmit={this.props.onSubmit}
         >
           <FormGroup>
-            <input name="ignore_blank" value="true" type="hidden" />
             <FormControl
               type="text"
               name={this.props.attribute}

--- a/src/decorators/artwork_attribute_updatable.js
+++ b/src/decorators/artwork_attribute_updatable.js
@@ -11,15 +11,32 @@ const ArtworkAttributeUpdatable = Wrapped => {
       this.onSubmit = this.onSubmit.bind(this);
     }
 
+    /*
+     * Custom formatting of data for updating the artwork or edition set.
+     *
+     * @param {object} data Updated data object; usually serialized from the form.
+     * @return {object} Formatted data object ready to be sent to the server.
+     */
+    prepareData(data) {
+      const prepared = { ignore_blank: true };
+      const key = this.props.isEditionSet ? "edition_set" : "artwork";
+
+      prepared[key] = data;
+      return prepared;
+    }
+
     onSubmit(e) {
       e.preventDefault();
       this.setState({artwork: this.state.artwork, loading: true});
 
-      const data = serializeFormDataToObject($(e.target));
+      const formData = serializeFormDataToObject($(e.target));
       $.ajax({
         url: this.props.saveUrl,
-        type: "PATCH",
-        data: {artwork: data},
+        // TODO: PATCH requests won't send data correctly in capybara-webkit/Qt.
+        // Let's use PUT for now.
+        // https://github.com/thoughtbot/capybara-webkit/issues/553
+        type: "PUT",
+        data: this.prepareData(formData),
         dataType: "json"
       }).done((artwork) => {
         const updated = _.pick(artwork, _.keys(this.props.artwork));

--- a/test/artwork_availability_quick_edit.js
+++ b/test/artwork_availability_quick_edit.js
@@ -41,7 +41,6 @@ describe('ArtworkAvailabilityQuickEdit', () => {
     });
 
     it('renders the form with proper fields', () => {
-      $root.find('form input[name="ignore_blank"]').val().should.equal('true');
       $root.find('form select[name="availability"]').val().should.equal('for sale');
     });
   });
@@ -75,8 +74,8 @@ describe('ArtworkAvailabilityQuickEdit', () => {
         $.ajax.should.be.calledOnce();
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
-          type: 'PATCH',
-          data: {artwork: {ignore_blank: "true", availability: "not for sale"}},
+          type: 'PUT',
+          data: {ignore_blank: true, artwork: {availability: "not for sale"}},
           dataType: 'json'
         })
       });

--- a/test/artwork_price_quick_edit.js
+++ b/test/artwork_price_quick_edit.js
@@ -72,7 +72,6 @@ describe('ArtworkPriceQuickEdit', () => {
     });
 
     it('renders the form with proper fields', () => {
-      $root.find('form input[name="ignore_blank"]').val().should.equal('true');
       $root.find('form input[name="price_listed"]').val().should.equal('100');
     });
   });
@@ -99,8 +98,8 @@ describe('ArtworkPriceQuickEdit', () => {
         $.ajax.should.be.calledOnce();
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
-          type: 'PATCH',
-          data: {artwork: {ignore_blank: "true", price_listed: "199"}},
+          type: 'PUT',
+          data: {ignore_blank: true, artwork: {price_listed: "199"}},
           dataType: 'json'
         })
       });

--- a/test/artwork_price_visibility_quick_edit.js
+++ b/test/artwork_price_visibility_quick_edit.js
@@ -40,7 +40,6 @@ describe('ArtworkPriceVisibilityQuickEdit', () => {
     });
 
     it('renders the form with proper fields', () => {
-      $root.find('form input[name="ignore_blank"]').val().should.equal('true');
       $root.find('form select[name="display_price"]').val().should.equal('hidden');
     });
   });
@@ -73,8 +72,8 @@ describe('ArtworkPriceVisibilityQuickEdit', () => {
         $.ajax.should.be.calledOnce();
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
-          type: 'PATCH',
-          data: {artwork: {ignore_blank: "true", display_price: "range"}},
+          type: 'PUT',
+          data: {ignore_blank: true, artwork: {display_price: "range"}},
           dataType: 'json'
         })
       });

--- a/test/base/inline_dropdown.js
+++ b/test/base/inline_dropdown.js
@@ -87,14 +87,6 @@ describe('InlineDropdown', () => {
       const instance = ReactDOM.render(React.createElement(InlineDropdown, props), el);
       const root = ReactDOM.findDOMNode(instance);
     });
-
-    it('includes a hidden ignore_blank input', () => {
-      const props = {object: {}, attribute: "whatever", options: []};
-      const instance = ReactDOM.render(React.createElement(InlineDropdown, props), el);
-      const root = ReactDOM.findDOMNode(instance);
-
-      $(root).find('form input[name="ignore_blank"]').val().should.equal('true');
-    });
   });
 
   describe('#optionLabelByValue', () => {

--- a/test/base/inline_text_input.js
+++ b/test/base/inline_text_input.js
@@ -64,13 +64,5 @@ describe('InlineTextInput', () => {
 
       $(root).find('form button[type="submit"]').text().should.equal('儲存');
     });
-
-    it('includes a hidden ignore_blank input', () => {
-      const props = {object: {}, attribute: "whatever"};
-      const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
-      const root = ReactDOM.findDOMNode(instance);
-
-      $(root).find('form input[name="ignore_blank"]').val().should.equal('true');
-    });
   });
 });

--- a/test/decorators/artwork_attribute_updatable.js
+++ b/test/decorators/artwork_attribute_updatable.js
@@ -23,6 +23,55 @@ describe('ArtworkAttributeUpdatable', () => {
     $.ajax.restore();
   });
 
+  describe('#prepareData', () => {
+    describe('artwork', () => {
+      it('returns data wrapped in artwork', () => {
+        const props = {
+          artwork: {title: "Mona Lisa"},
+          saveUrl: "/api/artworks/mona-lisa"
+        };
+
+        instance = ReactDOM.render(
+          React.createElement(DecoratedComponent, props), el);
+
+        instance.prepareData({
+          title: "Mona Lisa II",
+          year: "1503 - 1517"
+        }).should.eql({
+          ignore_blank: true,
+          artwork: {
+            title: "Mona Lisa II",
+            year: "1503 - 1517"
+          }
+        });
+      });
+    });
+
+    describe('edition set', () => {
+      it('returns data wrapped in artwork', () => {
+        const props = {
+          artwork: {title: "Mona Lisa"},
+          isEditionSet: true,
+          saveUrl: "/api/artworks/mona-lisa"
+        };
+
+        instance = ReactDOM.render(
+          React.createElement(DecoratedComponent, props), el);
+
+        instance.prepareData({
+          title: "Mona Lisa II",
+          year: "1503 - 1517"
+        }).should.eql({
+          ignore_blank: true,
+          edition_set: {
+            title: "Mona Lisa II",
+            year: "1503 - 1517"
+          }
+        });
+      });
+    });
+  });
+
   describe('#onSubmit', () => {
     let dfd, $form;
 
@@ -59,8 +108,8 @@ describe('ArtworkAttributeUpdatable', () => {
       $.ajax.calledOnce.should.be.true();
       $.ajax.args[0][0].should.eql({
         url: "/api/artworks/mona-lisa",
-        type: "PATCH",
-        data: {artwork: {ignore_blank: "true", title: "Portrait of Mona Lisa"}},
+        type: "PUT",
+        data: {ignore_blank: true, artwork: {ignore_blank: "true", title: "Portrait of Mona Lisa"}},
         dataType: "json"
       });
     });


### PR DESCRIPTION
## Problem

We also want to use the quick edit components to update edition sets.
## Solution

The "for sale" part of an artwork and edition set is very similar. Let's DRY ourselves by adding a new `isEditionSet` prop for formatting/preparing data sent to the server. `saveUrl` is already there in props, so we can use a different endpoint if we want to.
