### PR TITLE
Use internal display price for artwork price quick edit readonly display; input placeholder

### DIFF
--- a/src/artwork_price_quick_edit.js
+++ b/src/artwork_price_quick_edit.js
@@ -3,11 +3,17 @@ import InlineTextInput from './base/inline_text_input';
 import ArtworkAttributeUpdatable from './decorators/artwork_attribute_updatable';
 
 class InlineArtworkPrice extends React.Component {
+  display() {
+    return this.props.artwork && this.props.artwork.internal_display_price;
+  }
+
   render() {
     return <InlineTextInput {...this.props}
+      placeholder="e.g. 3500"
       className="crystals-artwork-price"
       object={this.props.artwork}
       attribute="price_listed"
+      display={this.display()}
     />;
   }
 }

--- a/src/base/inline_text_input.js
+++ b/src/base/inline_text_input.js
@@ -8,6 +8,11 @@ import { t } from '../helpers/translation';
 import { appendClasses } from '../helpers/dom_utils';
 
 class InlineTextInput extends React.Component {
+  display() {
+    return this.props.display ?
+      this.props.display : this.props.object[this.props.attribute];
+  }
+
   render() {
     const classNames = "crystals-inline-component crystals-inline-text-input";
 
@@ -17,7 +22,7 @@ class InlineTextInput extends React.Component {
         data-component-state={this.props.loading ? 'loading' : 'reading'}
       >
         <div data-element-type="readonly">
-          {this.props.object[this.props.attribute]}
+          {this.display()}
         </div>
         <Form
           inline
@@ -30,6 +35,7 @@ class InlineTextInput extends React.Component {
               type="text"
               name={this.props.attribute}
               disabled={this.props.loading}
+              placeholder={this.props.placeholder}
               defaultValue={this.props.object[this.props.attribute]}
             />
             <Button
@@ -50,6 +56,8 @@ InlineTextInput.propTypes = {
   object: React.PropTypes.object.isRequired,
   attribute: React.PropTypes.string.isRequired,
   className: React.PropTypes.string,
+  display: React.PropTypes.string,
+  placeholder: React.PropTypes.string,
   loading: React.PropTypes.bool,
   onSubmit: React.PropTypes.func,
   t: React.PropTypes.object

--- a/test/artwork_price_quick_edit.js
+++ b/test/artwork_price_quick_edit.js
@@ -76,6 +76,42 @@ describe('ArtworkPriceQuickEdit', () => {
     });
   });
 
+  describe('displaying readonly value', () => {
+    let $root;
+
+    context('artwork with internal display price', () => {
+      beforeEach(() => {
+        const props = {
+          artwork: {price_listed: 1000, internal_display_price: '£1,000'},
+          saveUrl: '/api/artworks/mona-lisa'
+        };
+        instance = ReactDOM.render(
+          React.createElement(ArtworkPriceQuickEdit, props), el);
+        $root = $(ReactDOM.findDOMNode(instance));
+      });
+
+      it('renders internal display price', () => {
+        $root.find('[data-element-type="readonly"]').text().should.equal("£1,000");
+      });
+    });
+
+    context('artwork without internal display price', () => {
+      beforeEach(() => {
+        const props = {
+          artwork: {price_listed: 1000},
+          saveUrl: '/api/artworks/mona-lisa'
+        };
+        instance = ReactDOM.render(
+          React.createElement(ArtworkPriceQuickEdit, props), el);
+        $root = $(ReactDOM.findDOMNode(instance));
+      });
+
+      it('renders price listed', () => {
+        $root.find('[data-element-type="readonly"]').text().should.equal("1000");
+      });
+    });
+  });
+
   describe('updating artwork price', () => {
     let dfd, $root;
 

--- a/test/base/inline_text_input.js
+++ b/test/base/inline_text_input.js
@@ -33,6 +33,22 @@ describe('InlineTextInput', () => {
       });
     });
 
+    it("renders value for readonly state by object's attribute by default", () => {
+      const props = {object: {price: "3500"}, attribute: "price"};
+      const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
+      const root = ReactDOM.findDOMNode(instance);
+
+      $(root).find('[data-element-type="readonly"]').text().should.equal("3500");
+    });
+
+    it('renders value for readonly state by props', () => {
+      const props = {object: {price: "3500"}, attribute: "price", display: "£3,500"};
+      const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
+      const root = ReactDOM.findDOMNode(instance);
+
+      $(root).find('[data-element-type="readonly"]').text().should.equal("£3,500");
+    });
+
     it('renders the reading state by default', () => {
       const props = {object: {}, attribute: "whatever"};
       const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);


### PR DESCRIPTION
- Use `internal_display_price` for artwork price quick edit readonly display.
- Add placeholder to the text input.
