### PR TITLE
Change state modeling; trigger event on update errors.

### DIFF
--- a/src/base/inline_dropdown.js
+++ b/src/base/inline_dropdown.js
@@ -35,7 +35,7 @@ class InlineDropdown extends React.Component {
     return (
       <div
         className={appendClasses(this.props.className, classNames)}
-        data-component-state={this.props.loading ? 'loading' : 'reading'}
+        data-component-state={this.props.state || "inited"}
       >
         <div data-element-type="readonly">
           {this.optionLabelByValue(this.props.value)}
@@ -47,11 +47,13 @@ class InlineDropdown extends React.Component {
           action="javascript:void(0);"
           onSubmit={this.props.onSubmit}
         >
-          <FormGroup>
+          <FormGroup
+            className={this.props.state == "errored" ? "has-error" : null}
+          >
             <FormControl
               componentClass="select"
               name={this.props.attribute}
-              disabled={this.props.loading}
+              disabled={this.props.state == "updating"}
               value={this.props.value}
               onChange={this.submitForm}
             >
@@ -70,7 +72,7 @@ InlineDropdown.propTypes = {
   options: React.PropTypes.array.isRequired,
   value: React.PropTypes.string,
   className: React.PropTypes.string,
-  loading: React.PropTypes.bool,
+  state: React.PropTypes.string,
   onSubmit: React.PropTypes.func,
 };
 

--- a/src/base/inline_text_input.js
+++ b/src/base/inline_text_input.js
@@ -13,13 +13,17 @@ class InlineTextInput extends React.Component {
       this.props.display : this.props.object[this.props.attribute];
   }
 
+  isUpdating() {
+    return this.props.state == "updating";
+  }
+
   render() {
     const classNames = "crystals-inline-component crystals-inline-text-input";
 
     return (
       <div
         className={appendClasses(this.props.className, classNames)}
-        data-component-state={this.props.loading ? 'loading' : 'reading'}
+        data-component-state={this.props.state || "inited"}
       >
         <div data-element-type="readonly">
           {this.display()}
@@ -30,18 +34,20 @@ class InlineTextInput extends React.Component {
           action="javascript:void(0);"
           onSubmit={this.props.onSubmit}
         >
-          <FormGroup>
+          <FormGroup
+            className={this.props.state == "errored" ? "has-error" : null}
+          >
             <FormControl
               type="text"
               name={this.props.attribute}
-              disabled={this.props.loading}
+              disabled={this.isUpdating()}
               placeholder={this.props.placeholder}
               defaultValue={this.props.object[this.props.attribute]}
             />
             <Button
               type="submit"
-              disabled={this.props.loading}
-              className={this.props.loading ? 'is-loading' : null}
+              disabled={this.isUpdating()}
+              className={this.isUpdating() ? 'is-loading' : null}
             >
               {t(this.props.t, 'forms.save')}
             </Button>
@@ -58,7 +64,7 @@ InlineTextInput.propTypes = {
   className: React.PropTypes.string,
   display: React.PropTypes.string,
   placeholder: React.PropTypes.string,
-  loading: React.PropTypes.bool,
+  state: React.PropTypes.string,
   onSubmit: React.PropTypes.func,
   t: React.PropTypes.object
 };

--- a/test/artwork_price_quick_edit.js
+++ b/test/artwork_price_quick_edit.js
@@ -34,8 +34,9 @@ describe('ArtworkPriceQuickEdit', () => {
 
       console.error.should.be.called();
       console.error.should.be.calledWithExactly(
-        "Warning: Failed propType: Required prop `artwork` was not " +
-        "specified in `ArtworkAttributeUpdatableComponent`."
+        "Warning: Failed prop type: Required prop `artwork` was not " +
+        "specified in `ArtworkAttributeUpdatableComponent`.\n" +
+        "    in ArtworkAttributeUpdatableComponent"
       );
     });
 
@@ -48,8 +49,9 @@ describe('ArtworkPriceQuickEdit', () => {
 
       console.error.should.be.called();
       console.error.should.be.calledWithExactly(
-        "Warning: Failed propType: Required prop `saveUrl` was not " +
-        "specified in `ArtworkAttributeUpdatableComponent`."
+        "Warning: Failed prop type: Required prop `saveUrl` was not " +
+        "specified in `ArtworkAttributeUpdatableComponent`.\n" +
+        "    in ArtworkAttributeUpdatableComponent"
       );
     });
   });

--- a/test/base/inline_dropdown.js
+++ b/test/base/inline_dropdown.js
@@ -147,7 +147,7 @@ describe('InlineDropdown', () => {
 
     it('calls props.onSubmit after option change event (via dispatchEvent)', () => {
       const select = $root.find('select').get(0);
-      const event = new Event('change', {bubbles: true, cancelable: false});
+      const event = new window.Event('change', {bubbles: true, cancelable: false});
 
       instance.props.onSubmit.should.not.be.called();
       // TODO: dispatchEvent won't work with detached element here so we have

--- a/test/base/inline_dropdown.js
+++ b/test/base/inline_dropdown.js
@@ -37,20 +37,20 @@ describe('InlineDropdown', () => {
       });
     });
 
-    it('renders the reading state by default', () => {
+    it('renders the inited state by default', () => {
       const props = {object: {}, attribute: "whatever", options: []};
       const instance = ReactDOM.render(React.createElement(InlineDropdown, props), el);
       const root = ReactDOM.findDOMNode(instance);
 
-      $(root).attr('data-component-state').should.equal('reading');
+      $(root).attr('data-component-state').should.equal('inited');
     });
 
-    it('renders the loading state by props', () => {
-      const props = {object: {}, attribute: "whatever", options: [], loading: true};
+    it('renders the state by props', () => {
+      const props = {object: {}, attribute: "whatever", options: [], state: "errored"};
       const instance = ReactDOM.render(React.createElement(InlineDropdown, props), el);
       const root = ReactDOM.findDOMNode(instance);
 
-      $(root).attr('data-component-state').should.equal('loading');
+      $(root).attr('data-component-state').should.equal("errored");
     });
 
     it('renders the dropdown with proper options', () => {

--- a/test/base/inline_text_input.js
+++ b/test/base/inline_text_input.js
@@ -49,20 +49,20 @@ describe('InlineTextInput', () => {
       $(root).find('[data-element-type="readonly"]').text().should.equal("£3,500");
     });
 
-    it('renders the reading state by default', () => {
+    it('renders the inited state by default', () => {
       const props = {object: {}, attribute: "whatever"};
       const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
       const root = ReactDOM.findDOMNode(instance);
 
-      $(root).attr('data-component-state').should.equal('reading');
+      $(root).attr('data-component-state').should.equal('inited');
     });
 
-    it('renders the loading state by props', () => {
-      const props = {object: {}, attribute: "whatever", loading: true};
+    it('renders the state by props', () => {
+      const props = {object: {}, attribute: "whatever", state: 'inited'};
       const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
       const root = ReactDOM.findDOMNode(instance);
 
-      $(root).attr('data-component-state').should.equal('loading');
+      $(root).attr('data-component-state').should.equal('inited');
     });
 
     it('renders the input with proper name and value', () => {

--- a/test/decorators/artwork_attribute_updatable.js
+++ b/test/decorators/artwork_attribute_updatable.js
@@ -95,13 +95,8 @@ describe('ArtworkAttributeUpdatable', () => {
       $form.on('submit', instance.onSubmit).trigger('submit');
     });
 
-    it('sets the loading state on submit', () => {
-      instance.state.loading.should.be.true()
-    });
-
-    it('unsets the loading state after submit', () => {
-      dfd.resolve();
-      instance.state.loading.should.be.false()
+    it('sets the updating state on submit', () => {
+      instance.state.state.should.equal("updating");
     });
 
     it('makes a proper request to update artwork attribute', () => {
@@ -114,9 +109,38 @@ describe('ArtworkAttributeUpdatable', () => {
       });
     });
 
-    it('updates the artwork after submit', () => {
-      dfd.resolve({title: "Portrait of Mona Lisa"});
-      instance.state.artwork.should.eql({title: "Portrait of Mona Lisa"});
+    context('with successful update', () => {
+      it('updates the artwork after submit', () => {
+        dfd.resolve({title: "Portrait of Mona Lisa"});
+        instance.state.artwork.should.eql({title: "Portrait of Mona Lisa"});
+      });
+
+      it('sets the updated state after submit', () => {
+        dfd.resolve();
+        instance.state.state.should.equal("updated");
+      });
+    });
+
+    context('with failed update', () => {
+      const error = {error: "Not Authorized"};
+
+      it('does not update the artwork after submit', () => {
+        dfd.resolve(error);
+        instance.state.artwork.should.eql({title: "Mona Lisa"});
+      });
+
+      it('sets the errored state after submit', () => {
+        dfd.resolve(error);
+        instance.state.state.should.equal("errored");
+      });
+
+      it('triggers an error event on the form', (done) => {
+        $form.one('error.crystals', (event, data) => {
+          data.should.eql(error);
+          done();
+        })
+        dfd.resolve(error);
+      });
     });
   });
 });


### PR DESCRIPTION
- Support more states.
  
  We need to differentiate various states on the UI. This PR include possible states: "inited", "updating", "updated", "errored".
- Trigger an `error.crystals` event on update error.
  
  This is not ideal but we need to let the outside world handle the errors. Let's trigger an event for whoever is interested for now.
