### PR TITLE
Front-end tweaks for inline dropdown and text input.

### DIFF
--- a/src/base/inline_dropdown.js
+++ b/src/base/inline_dropdown.js
@@ -29,6 +29,10 @@ class InlineDropdown extends React.Component {
     ReactDOM.findDOMNode(this.refs.form).dispatchEvent(event);
   }
 
+  isUpdating() {
+    return this.props.state == "updating";
+  }
+
   render() {
     const classNames = "crystals-inline-component crystals-inline-dropdown";
 
@@ -50,15 +54,17 @@ class InlineDropdown extends React.Component {
           <FormGroup
             className={this.props.state == "errored" ? "has-error" : null}
           >
-            <FormControl
-              componentClass="select"
-              name={this.props.attribute}
-              disabled={this.props.state == "updating"}
-              value={this.props.value}
-              onChange={this.submitForm}
-            >
-              {this.props.options.map(o => <option key={o[1]} value={o[1]}>{o[0]}</option>)}
-            </FormControl>
+            <div className={`overlayable-input ${this.isUpdating() ? "is-loading" : ""}`}>
+              <FormControl
+                componentClass="select"
+                name={this.props.attribute}
+                disabled={this.isUpdating()}
+                value={this.props.value}
+                onChange={this.submitForm}
+              >
+                {this.props.options.map(o => <option key={o[1]} value={o[1]}>{o[0]}</option>)}
+              </FormControl>
+            </div>
           </FormGroup>
         </Form>
       </div>

--- a/src/base/inline_text_input.js
+++ b/src/base/inline_text_input.js
@@ -46,10 +46,11 @@ class InlineTextInput extends React.Component {
             />
             <Button
               type="submit"
+              bsStyle="primary"
               disabled={this.isUpdating()}
               className={this.isUpdating() ? 'is-loading' : null}
             >
-              {t(this.props.t, 'forms.save')}
+              {t(this.props.t, 'actions.save')}
             </Button>
           </FormGroup>
         </Form>

--- a/test/base/inline_text_input.js
+++ b/test/base/inline_text_input.js
@@ -74,7 +74,7 @@ describe('InlineTextInput', () => {
     });
 
     it('renders the button with proper translation', () => {
-      const props = {object: {}, attribute: "whatever", t: {forms: {save: '儲存'}}};
+      const props = {object: {}, attribute: "whatever", t: {actions: {save: '儲存'}}};
       const instance = ReactDOM.render(React.createElement(InlineTextInput, props), el);
       const root = ReactDOM.findDOMNode(instance);
 


### PR DESCRIPTION
- Wrap the inline dropdown `<select>` inside of a `.overlayable-input` div, so we can style the dropdown a bit easier. Pseudo elements are not supported for `<select>`.
- Minor copy and style changes to the inline text input.
