### PR TITLE
Update react-bootstrap to solve the React.PropTypes validation warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "jquery": "^2.2.4",
-    "react-bootstrap": "^0.29.4",
+    "react-bootstrap": "^0.30.3",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Re: https://github.com/react-bootstrap/react-bootstrap/pull/2095

We've seen some warnings in the console after upgrading to React 15.3, similar to the issue [reported](https://github.com/react-bootstrap/react-bootstrap/issues/2097). Let's update react-bootstrap to solve that.

<img width="1440" alt="screen shot 2016-08-22 at 2 41 40 pm" src="https://cloud.githubusercontent.com/assets/796573/17867177/7095bbee-6877-11e6-8853-8b2571d14e56.png">
