### PR TITLE
Don't ignore blank fields.

### DIFF
--- a/src/decorators/artwork_attribute_updatable.js
+++ b/src/decorators/artwork_attribute_updatable.js
@@ -22,7 +22,7 @@ const ArtworkAttributeUpdatable = Wrapped => {
      * @return {object} Formatted data object ready to be sent to the server.
      */
     prepareData(data) {
-      const prepared = { ignore_blank: true };
+      const prepared = {};
       const key = this.props.isEditionSet ? "edition_set" : "artwork";
 
       prepared[key] = data;

--- a/test/artwork_availability_quick_edit.js
+++ b/test/artwork_availability_quick_edit.js
@@ -75,7 +75,7 @@ describe('ArtworkAvailabilityQuickEdit', () => {
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
           type: 'PUT',
-          data: {ignore_blank: true, artwork: {availability: "not for sale"}},
+          data: {artwork: {availability: "not for sale"}},
           dataType: 'json'
         })
       });

--- a/test/artwork_price_quick_edit.js
+++ b/test/artwork_price_quick_edit.js
@@ -137,7 +137,7 @@ describe('ArtworkPriceQuickEdit', () => {
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
           type: 'PUT',
-          data: {ignore_blank: true, artwork: {price_listed: "199"}},
+          data: {artwork: {price_listed: "199"}},
           dataType: 'json'
         })
       });

--- a/test/artwork_price_visibility_quick_edit.js
+++ b/test/artwork_price_visibility_quick_edit.js
@@ -73,7 +73,7 @@ describe('ArtworkPriceVisibilityQuickEdit', () => {
         $.ajax.firstCall.should.be.calledWith({
           url: '/api/artworks/mona-lisa',
           type: 'PUT',
-          data: {ignore_blank: true, artwork: {display_price: "range"}},
+          data: {artwork: {display_price: "range"}},
           dataType: 'json'
         })
       });

--- a/test/decorators/artwork_attribute_updatable.js
+++ b/test/decorators/artwork_attribute_updatable.js
@@ -38,7 +38,6 @@ describe('ArtworkAttributeUpdatable', () => {
           title: "Mona Lisa II",
           year: "1503 - 1517"
         }).should.eql({
-          ignore_blank: true,
           artwork: {
             title: "Mona Lisa II",
             year: "1503 - 1517"
@@ -62,7 +61,6 @@ describe('ArtworkAttributeUpdatable', () => {
           title: "Mona Lisa II",
           year: "1503 - 1517"
         }).should.eql({
-          ignore_blank: true,
           edition_set: {
             title: "Mona Lisa II",
             year: "1503 - 1517"
@@ -88,7 +86,6 @@ describe('ArtworkAttributeUpdatable', () => {
       $.ajax.returns(dfd);
       $form = $(`
         <form>
-          <input name="ignore_blank" value="true" />
           <input name="title" value="Portrait of Mona Lisa" />
         </form>
       `);
@@ -104,7 +101,7 @@ describe('ArtworkAttributeUpdatable', () => {
       $.ajax.args[0][0].should.eql({
         url: "/api/artworks/mona-lisa",
         type: "PUT",
-        data: {ignore_blank: true, artwork: {ignore_blank: "true", title: "Portrait of Mona Lisa"}},
+        data: {artwork: {title: "Portrait of Mona Lisa"}},
         dataType: "json"
       });
     });


### PR DESCRIPTION
## Problem

We used to do `ignore_blank: true` to avoid accidentally modifying other fields in our [complex/non-single-responsibility controller action](https://github.com/artsy/volt/blob/119d8d32063222598bd0eff0cf3a0f24b51245d3/app/controllers/artworks_controller.rb#L65); however, this prevent us from unsetting the fields we need.
## Solution

Let's not ignore the blank fields for now. There are [specific specs](https://github.com/artsy/volt/blob/119d8d32063222598bd0eff0cf3a0f24b51245d3/spec/features/artworks/quick_editing_spec.rb#L226) to check if we are sending the correct params when using quick edits, so it looks fine. But we should refactor/break down the controller action at some point to not couple everything together.
